### PR TITLE
[Android] Feature: enforce BT scan with first match

### DIFF
--- a/android/src/main/java/it/innove/DefaultScanManager.java
+++ b/android/src/main/java/it/innove/DefaultScanManager.java
@@ -29,11 +29,15 @@ import com.facebook.react.bridge.WritableMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.HashSet;
 
 @SuppressLint("MissingPermission")
 public class DefaultScanManager extends ScanManager {
 
     private boolean isScanning = false;
+
+    private boolean enforceFirstMatch = true;
+    private final HashSet<String> discoveredUuids = new HashSet<String>();
 
     public DefaultScanManager(ReactApplicationContext reactContext, BleManager bleManager) {
         super(reactContext, bleManager);
@@ -47,6 +51,13 @@ public class DefaultScanManager extends ScanManager {
 
         getBluetoothAdapter().getBluetoothLeScanner().stopScan(mScanCallback);
         isScanning = false;
+
+        // CLEANUP:
+        // Reset the enforceFirstMatch flag to false
+        this.enforceFirstMatch = false;
+        // Clear the discovered UUIDs after stopping the scan
+        this.discoveredUuids.clear();
+
         callback.invoke();
     }
 
@@ -54,6 +65,9 @@ public class DefaultScanManager extends ScanManager {
     public void scan(ReadableArray serviceUUIDs, final int scanSeconds, ReadableMap options, Callback callback) {
         ScanSettings.Builder scanSettingsBuilder = new ScanSettings.Builder();
         List<ScanFilter> filters = new ArrayList<>();
+
+        // Clear the discovered UUIDs before each scan (just to be sure)
+        this.discoveredUuids.clear();
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && options.hasKey("legacy")) {
             scanSettingsBuilder.setLegacy(options.getBoolean("legacy"));
@@ -72,6 +86,13 @@ public class DefaultScanManager extends ScanManager {
             }
             if (options.hasKey("callbackType")) {
                 scanSettingsBuilder.setCallbackType(options.getInt("callbackType"));
+            }
+        }
+
+        if (options.hasKey("enforceFirstMatch")) {
+            this.enforceFirstMatch = options.getBoolean("enforceFirstMatch");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                scanSettingsBuilder.setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES);
             }
         }
 
@@ -215,8 +236,21 @@ public class DefaultScanManager extends ScanManager {
         }
         bleManager.savePeripheral(peripheral);
 
+        if (this.enforceFirstMatch) {
+            // Skip sending event if the peripheral was already discovered
+            // This is to avoid sending the same peripheral multiple times over the bridge
+            // since using `callbackType = BleScanCallbackType.FirstMatch` not always works as expected
+            if (this.discoveredUuids.contains(result.getDevice().getAddress())) {
+                Log.i(BleManager.LOG_TAG, "Peripheral: " + info + " already discovered - skipping sending event");
+                return;
+            }
+        }
+
         WritableMap map = peripheral.asWritableMap();
         bleManager.sendEvent("BleManagerDiscoverPeripheral", map);
+
+        // Add the UUID to the discovered list
+        this.discoveredUuids.add(result.getDevice().getAddress());
     }
 
     private final ScanCallback mScanCallback = new ScanCallback() {

--- a/android/src/main/java/it/innove/DefaultScanManager.java
+++ b/android/src/main/java/it/innove/DefaultScanManager.java
@@ -36,7 +36,7 @@ public class DefaultScanManager extends ScanManager {
 
     private boolean isScanning = false;
 
-    private boolean enforceFirstMatch = true;
+    private boolean enforceFirstMatch = false;
     private final HashSet<String> discoveredUuids = new HashSet<String>();
 
     public DefaultScanManager(ReactApplicationContext reactContext, BleManager bleManager) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,21 @@ class BleManager extends NativeEventEmitter {
         }
       }
 
+      // (ANDROID)
+      // Enforce the same behaviour as the `callbackType = FirstMatch`
+      // but on the native `onDiscoveredPeripheral` callback level.
+      // This is a workaround for the fact that a few devices
+      // are not able to handle `callbackType = FirstMatch` properly.
+      // **IMPORTANT**: Setting this flag to `true` will automatically
+      // override the `callbackType` to `AllMatches`.
+      // Defaults to `false`.
+      if (scanningOptions.enforceFirstMatch == null) {
+        scanningOptions.enforceFirstMatch = false;
+      }
+      if (scanningOptions.enforceFirstMatch) {
+        scanningOptions.callbackType = BleScanCallbackType.AllMatches;
+      }
+
       bleManager.scan(
         serviceUUIDs,
         seconds,

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,6 +158,20 @@ export interface ScanOptions {
    */
   single?: boolean;
   companion?: boolean;
+
+  /**
+   * [android only]
+   * Enforce the same behaviour as the `callbackType = FirstMatch`
+   * but on the native `onDiscoveredPeripheral` callback level.
+   * This is a workaround for the fact that a few devices
+   * are not able to handle `callbackType = FirstMatch` properly.
+   * 
+   * **IMPORTANT**: Setting this flag to `true` will automatically
+   * override the `callbackType` to `AllMatches`.
+   * 
+   * Defaults to `false`.
+   * */
+  enforceFirstMatch?: boolean;
 }
 
 export interface CompanionScanOptions {


### PR DESCRIPTION
During the testing phase we discovered that Android's `ScanSettings.CALLBACK_TYPE_FIRST_MATCH` does not work on some devices _(Motorola G23 with Android 14 for example)_ and the BT scan does not return any detected devices as a result of this bug.

As a workaround, I implemented manual "first match" strategy on the native `onDiscoveredPeripheral` callback level.
User can set `enforceFirstMatch` flag from `ScanOptions` to true and it will make the native implementation to skip any subsequent advertisements from the already discovered BT device during that scan. The set of discovered devices is cleared before starting a new scan.